### PR TITLE
DOM-13058: Output node ips for backups later

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -3,6 +3,11 @@ output "ids" {
   value       = ["${azurerm_virtual_machine.this.*.id}"]
 }
 
+output "node_ips" {
+  description = "Comma-delimited string of VM node ips"
+  value       = "${local.node_ips}"
+}
+
 output "public_lb_id" {
   description = "Load balancer id"
   value       = "${var.enable_public_lb ? element(concat(azurerm_lb.public_lb.*.id, list("")), 0) : ""}"


### PR DESCRIPTION
We're setting up backups for etcd, and want to reference the individual servers when we do, so output them as a comma-delimited string.