### PR TITLE
DOM-16779: Make sure we pin ranchhand release too

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -160,7 +160,7 @@ variable "ranchhand_distro" {
 
 variable "release" {
   description = "Specify the RanchHand release version to use. Check https://github.com/dominodatalab/ranchhand/releases for a list of available releases."
-  default     = "latest"
+  default     = "v0.1.2-rc1"
 }
 
 variable "ranchhand_working_dir" {


### PR DESCRIPTION
We pinned the "terraform" release of ranchhand, but not the actual ranchhand binary itself.