### PR TITLE
update ranchhand to v0.4.0 and allow override of rancher_version

### DIFF
--- a/ranchhand.tf
+++ b/ranchhand.tf
@@ -12,12 +12,14 @@ data "null_data_source" "node_ips" {
 }
 
 module "ranchhand" {
-  source = "github.com/dominodatalab/ranchhand.git?ref=v0.3.5"
+  source = "github.com/dominodatalab/ranchhand.git?ref=v0.4.0"
 
   node_ips = data.null_data_source.node_ips.*.outputs.ip
 
   cert_ipaddresses = local.ranchhand_cert_ips
   cert_dnsnames    = var.ranchhand_cert_dnsnames
+
+  rancher_version = var.rancher_version
 
   ssh_username   = var.admin_username
   ssh_key_path   = var.ssh_private_key

--- a/variables.tf
+++ b/variables.tf
@@ -172,3 +172,8 @@ variable "admin_password" {
   description = "Password override for the initial admin user"
   default     = ""
 }
+
+variable "rancher_version" {
+  description = "Override for the installed Rancher version."
+  default     = ""
+}


### PR DESCRIPTION
Pick up Ranchhand release [v0.4.0](https://github.com/dominodatalab/ranchhand/releases/tag/v0.4.0).